### PR TITLE
allow the user to select vibe-d:data version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -7,7 +7,7 @@
 	"copyright": "Copyright © 2017, Robert burner Schadek",
 	"license": "LGPL",
 	"dependencies" : {
-		"vibe-d:data": ">=0.8.0-beta.1",
+		"vibe-d:data": "*",
 		"stringbuffer": ">=1.0.0"
 	}
 }


### PR DESCRIPTION
Hi,
It's more convenient to set dependency as "*". 
It allow to refer to "~master" on vibe-d like in this example:

```
"dependencies": {
    "vibe-d": "~master",
    "fastjwt": "~>1.0.0"	
}
``` 
