### PR TITLE
Use URLSafeBase64 to encode Payload

### DIFF
--- a/source/fastjwt/jwt.d
+++ b/source/fastjwt/jwt.d
@@ -67,7 +67,7 @@ void payloadToBase64(Out)(ref Out output, const(Json) payload) {
 	StringBuffer jsonString;
 	auto w = jsonString.writer();
 	writeJsonString(w, payload);
-	Base64.encode(jsonString.getData!(ubyte[])(), output.writer());
+	URLSafeBase64.encode(jsonString.getData!(ubyte[])(), output.writer());
 }
 
 void payloadToBase64(Out,Args...)(ref Out output, Args args)


### PR DESCRIPTION
According to https://datatracker.ietf.org/doc/html/rfc7515#section-3.1, the JWS Payload should be BASE64URL encoded, like the rest of the message.

